### PR TITLE
Fix: Body Overflow  in y-direction- Adjust Flex Direction for Buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -794,13 +794,15 @@ footer {
   } */
   .roadmap {
     display: flex;
+    align-items: center;
     flex-direction: column;
   }
 
   .roadmap_btns {
     width: 100%;
     display: flex;
-    flex-direction: row;
+    align-items: center;
+    /* flex-direction: row; */
   }
   .roadmap_btns button {
     width: 33%;
@@ -817,7 +819,8 @@ footer {
   .roadmap_btns_right {
     width: 100%;
     display: flex;
-    flex-direction: row;
+    align-items: center;
+    /* flex-direction: row; */
   }
 
   .img1 {


### PR DESCRIPTION
This pull request addresses the overflow issue in the Y-direction caused by the **Roadmap Section**. The flex direction for the roadmap buttons has been changed to `column` to better fit smaller screens, resolving the overflow and improving the user experience on mobile devices.

Fixes: #149 

### Changes Made

- Updated the flex direction of the roadmap buttons from `row` to `column` to ensure proper layout on smaller screens.
- This resolves the vertical overflow and aligns the content correctly on all screen sizes.

### Screenshots

|        BEFORE        |        AFTER         |
| :------------------: | :------------------: |
| <img width="206" alt="Screenshot 2024-10-06 at 3 50 28 AM" src="https://github.com/user-attachments/assets/f472a018-ec0e-4233-9cd2-f5d10b2e8b0f"> | <img width="173" alt="Screenshot 2024-10-06 at 3 49 39 AM" src="https://github.com/user-attachments/assets/b39611cc-4ff4-4132-bb4e-8bcebbe442b5"> |

### Checklist

- [x] Changed flex direction for roadmap buttons to `column`.
- [x] Tested the changes on multiple screen sizes to ensure responsiveness.
- [x] Code follows the established coding style guidelines.

Please review and merge. Thank you!