### PR TITLE
[FIXED]: Web Development Button Design in Roadmap section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -426,12 +426,6 @@ button:active {
   text-align: center;
 }
 
-.btn_web {
-  background-color: #ffffff;
-  color: #121212;
-  box-shadow: var(--hover-shadows);
-}
-
 .occur {
   color: #ffffff;
   background-color: #121212;

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
     </section>
     <div class="roadmap">
       <div class="roadmap_btns">
-        <button class="btn_web" onclick="setActive(this)">
+        <button onclick="setActive(this)">
           Web Development
         </button>
         <button class="btn_dsa" onclick="setActive(this)">DSA</button>


### PR DESCRIPTION
The "Web Development" button has a different appearance compared to the "DSA" and "Cyber Security" buttons before being hovered over. This inconsistency can be seen in the section before the footer on the webpage.

Expected Behavior:
The "Web Development" button should have the same style as the other buttons when not hovered.

Fix:
I have adjusted the styling so that the "Web Development" button now matches the other buttons in appearance before hover. The issue has been resolved, and I am ready to submit a pull request.

![image](https://github.com/user-attachments/assets/b2c697cc-18ce-4fdd-a91e-fd98c8512458)
